### PR TITLE
Switch to Pythia 8 as default

### DIFF
--- a/configure
+++ b/configure
@@ -17,8 +17,8 @@ if(($match = grep(/--help/i, @ARGV)) > 0) {
   print "    FLAG                 DESCRIPTION                                                 DEFAULT\n\n";
   print "    --prefix             Installation location (for 'make install')                  /usr/local/\n";
   print "\n enable/disable options with either --enable- or --disable- (eg --enable-lhapdf5 --disable-flux-drivers)\n\n";
-  print "    pythia6              Use the PYTHIA6 MC generator, assumed to be incl. w/ ROOT   default: enabled  \n";
-  print "    pythia8              Use the PYTHIA8 MC generator                                default: disabled \n";
+  print "    pythia6              Use the PYTHIA6 MC generator, assumed to be incl. w/ ROOT   default: disabled \n";
+  print "    pythia8              Use the PYTHIA8 MC generator                                default: enabled  \n";
   print "    incl                 Interface with INCL++ for nuclear transport                 default: disabled \n";
   print "    geant4               Interface with Geant4 for nuclear transport                 default: disabled \n";
   print "    lhapdf5              Use the LHAPDF5 parton density function library             default: enabled  \n";
@@ -54,7 +54,7 @@ if(($match = grep(/--help/i, @ARGV)) > 0) {
   print "    profiler-lib      Path to profiler library     needed if you --enable-profiler \n";
   print "    doxygen-path      Doxygen binary path          needed if you --enable-doxygen-doc  (if unset: checks for a \$DOXYGENPATH env.var.) \n";
 
-  print "    pythia6-lib       PYTHIA6 libraries path       always needed                       (if unset: checks for a \$PYTHIA6 env.var., then tries to auto-detect it) \n";
+  print "    pythia6-lib       PYTHIA6 libraries path       needed if you --enable-pythia6       (if unset: checks for a \$PYTHIA6 env.var., then tries to auto-detect it) \n";
   print "    pythia8-inc       PYTHIA8 includes path        needed if you --enable-pythia8      (if unset: checks for a \$PYTHIA8_INC env.var., then tries to auto-detect it) \n";
   print "    pythia8-lib       PYTHIA8 libraries path       needed if you --enable-pythia8      (if unset: checks for a \$PYTHIA8_LIB env.var.. then tries to auto-detect it) \n";
   print "    incl-inc          INCL++ includes path         needed if you --enable-incl         (if unset: tries to auto-detect it) \n";
@@ -151,8 +151,8 @@ print MKCONF "GENIE_INSTALLATION_PATH=$prefix\n";
 
 # Default --enable/--disable config options (for a minimal genie build)
 #
-my $gopt_enable_pythia6              = "YES";
-my $gopt_enable_pythia8              = "NO";
+my $gopt_enable_pythia6              = "NO";
+my $gopt_enable_pythia8              = "YES";
 my $gopt_enable_lhapdf5              = "YES";
 my $gopt_enable_lhapdf6              = "NO";
 my $gopt_enable_apfel                = "NO";

--- a/src/make/Make.include
+++ b/src/make/Make.include
@@ -157,13 +157,13 @@ endif
 #                             APFEL
 #-------------------------------------------------------------------
 
-APFEL_LIBRARIES = 
+APFEL_LIBRARIES =
 APFEL_INCLUDES  =
 
-ifeq ($(strip $(GOPT_ENABLE_APFEL)),YES) 
+ifeq ($(strip $(GOPT_ENABLE_APFEL)),YES)
 
 APFEL_INCLUDES  = -I$(GOPT_WITH_APFEL_INC)
-APFEL_LIBRARIES = -L$(GOPT_WITH_APFEL_LIB) -lAPFEL 
+APFEL_LIBRARIES = -L$(GOPT_WITH_APFEL_LIB) -lAPFEL
 
 endif
 
@@ -250,7 +250,7 @@ endif
 
 PY6ROOT_LIBRARY = -lEGPythia6
 else
-  $(info GOPT_ENABLE_PYTHIA6 is NO)
+  #$(info GOPT_ENABLE_PYTHIA6 is NO)
 endif
 
 #-------------------------------------------------------------------


### PR DESCRIPTION
This PR updates the build machinery to turn Pythia 8 on by default and disable Pythia 6 by default. It's intended for use together with the corresponding XML updates.